### PR TITLE
Fix __toString and getStatement throwing exception 

### DIFF
--- a/src/Mapper/MapperSelect.php
+++ b/src/Mapper/MapperSelect.php
@@ -43,6 +43,8 @@ class MapperSelect implements SubselectInterface
      */
     public function __toString()
     {
+        $this->tableColumns();
+
         return $this->tableSelect->__toString();
     }
 
@@ -68,6 +70,8 @@ class MapperSelect implements SubselectInterface
     // subselect interface
     public function getStatement()
     {
+        $this->tableColumns();
+
         return $this->tableSelect->getStatement();
     }
 
@@ -85,7 +89,7 @@ class MapperSelect implements SubselectInterface
 
     public function fetchRecord()
     {
-        $this->tableSelect->cols($this->tableSelect->getColNames());
+        $this->tableColumns();
         $cols = $this->fetchOne();
         if (! $cols) {
             return false;
@@ -96,7 +100,7 @@ class MapperSelect implements SubselectInterface
 
     public function fetchRecordSet()
     {
-        $this->tableSelect->cols($this->tableSelect->getColNames());
+        $this->tableColumns();
 
         $data = $this->fetchAll();
         if (! $data) {
@@ -108,7 +112,7 @@ class MapperSelect implements SubselectInterface
 
     public function fetchRecordsArray()
     {
-        $this->tableSelect->cols($this->tableSelect->getColNames());
+        $this->tableColumns();
 
         $records = [];
         $data = $this->fetchAll();
@@ -117,4 +121,12 @@ class MapperSelect implements SubselectInterface
         }
         return $records;
     }
+
+    protected function tableColumns()
+    {
+        if (! $this->tableSelect->hasCols()) {
+            $this->tableSelect->cols($this->tableSelect->getColNames());
+        }
+    }
+
 }

--- a/tests/Mapper/MapperSelectTest.php
+++ b/tests/Mapper/MapperSelectTest.php
@@ -51,12 +51,42 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $this->assertSameSql($expect, $actual);
     }
 
+    public function testGetStatementWithOutColumnsPassed()
+    {
+        $expect = '
+            SELECT
+                id,
+                name,
+                building,
+                floor
+            FROM
+                "employee"
+        ';
+        $actual = $this->select->getStatement();
+        $this->assertSameSql($expect, $actual);
+    }
+
     public function test__toString()
     {
         $this->select->cols(['*']);
         $expect = '
             SELECT
                 *
+            FROM
+                "employee"
+        ';
+        $actual = $this->select->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
+    public function testWithOutColumnsPassed__toString()
+    {
+        $expect = '
+            SELECT
+                id,
+                name,
+                building,
+                floor
             FROM
                 "employee"
         ';
@@ -140,5 +170,23 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             ->fetchValue();
 
         $this->assertSame($expect, $actual);
+    }
+
+    public function testFetchRecordGetStatement()
+    {
+        $expect = '
+            SELECT
+                name
+            FROM
+                "employee"
+        ';
+
+        $this->select
+            ->cols(['name'])
+            ->fetchRecord();
+
+        $actual = $this->select->__toString();
+
+        $this->assertSameSql($expect, $actual);
     }
 }


### PR DESCRIPTION
When there is no columns add the default columns. When there is columns specified, don't add the columns again.

Fixes #9 .
