### PR TITLE
(Fix?) Add support for empty ManyToMany recordsets

### DIFF
--- a/src/Relationship/ManyToMany.php
+++ b/src/Relationship/ManyToMany.php
@@ -32,8 +32,13 @@ class ManyToMany extends AbstractRelationship
         }
 
         $throughRecordSet = $nativeRecord->{$this->throughName};
-        $select = $this->selectForRecordSet($throughRecordSet, $custom);
-        $nativeRecord->{$this->name} = $select->fetchRecordSet();
+        $result = [];
+        if ($throughRecordSet instanceof RecordSetInterface) {
+            $select = $this->selectForRecordSet($throughRecordSet, $custom);
+            $result = $select->fetchRecordSet();
+        }
+
+        $nativeRecord->{$this->name} = $result;
     }
 
     public function stitchIntoRecordSet(

--- a/tests/AtlasTest.php
+++ b/tests/AtlasTest.php
@@ -728,41 +728,8 @@ class AtlasTest extends \PHPUnit_Framework_TestCase
                 ],
             ],
             'taggings' => [
-                0 => [
-                    'tagging_id' => '7',
-                    'thread_id' => '3',
-                    'tag_id' => '3',
-                ],
-                1 => [
-                    'tagging_id' => '8',
-                    'thread_id' => '3',
-                    'tag_id' => '4',
-                ],
-                2 => [
-                    'tagging_id' => '9',
-                    'thread_id' => '3',
-                    'tag_id' => '5',
-                ],
             ],
             'tags' => [
-                0 => [
-                    'tag_id' => '3',
-                    'name' => 'baz',
-                    'taggings' => null,
-                    'threads' => null,
-                ],
-                1 => [
-                    'tag_id' => '4',
-                    'name' => 'dib',
-                    'taggings' => null,
-                    'threads' => null,
-                ],
-                2 => [
-                    'tag_id' => '5',
-                    'name' => 'zim',
-                    'taggings' => null,
-                    'threads' => null,
-                ],
             ],
         ],
     ];

--- a/tests/SqliteFixture.php
+++ b/tests/SqliteFixture.php
@@ -145,10 +145,13 @@ class SqliteFixture
             tag_id INTEGER NOT NULL
         )");
 
-        // add 3 tags to each thread
+        // add 3 tags to each thread except thread #3
         $stm = "INSERT INTO taggings (thread_id, tag_id) VALUES (?, ?)";
         for ($i = 0; $i < 20; $i ++) {
             $thread_id = $i + 1;
+            if($thread_id == 3) {
+                continue;
+            }
             $tags = [
                 (($i + 0) % 5) + 1,
                 (($i + 1) % 5) + 1,


### PR DESCRIPTION
I honestly haven't familiarized myself with this project very much yet, but it appears that without something like this patch, I get the following error when relationships are empty:

> Argument 1 passed to Atlas\Orm\Relationship\AbstractRelationship::selectForRecordSet() must be an instance of Atlas\Orm\Mapper\RecordSetInterface, array given, called in /vendor/atlas/orm/src/Relationship/ManyToMany.php on line 35 and defined

Perhaps I'm just doing something wrong though?
