### PR TITLE
Clone objects used internally so the original TableSelect have no issues

### DIFF
--- a/src/Mapper/MapperSelect.php
+++ b/src/Mapper/MapperSelect.php
@@ -217,4 +217,12 @@ class MapperSelect implements SubselectInterface
 
         return call_user_func($this->turnRowsIntoRecordSet, $rows, $this->with);
     }
+
+    /**
+     * Clone objects used internally
+     */
+    public function __clone()
+    {
+        $this->tableSelect = clone $this->tableSelect;
+    }
 }

--- a/src/Table/TableSelect.php
+++ b/src/Table/TableSelect.php
@@ -358,4 +358,12 @@ class TableSelect implements SubselectInterface
             $this->select->cols($this->colNames);
         }
     }
+
+    /**
+     * Clone objects used internally
+     */
+    public function __clone()
+    {
+        $this->select = clone $this->select;
+    }
 }

--- a/tests/Mapper/MapperTest.php
+++ b/tests/Mapper/MapperTest.php
@@ -388,6 +388,33 @@ class MapperTest extends \PHPUnit_Framework_TestCase
         $this->assertSameSql($expect, $actual);
     }
 
+    public function testCloneSelectDontAlterOriginalQuery()
+    {
+        $select = $this->mapper->select(['foo' => null])->cols(['foo']);
+        $expect = 'SELECT
+                foo
+            FROM
+                "employee"
+            WHERE
+                "employee"."foo" IS NULL
+        ';
+        $counter = clone $select;
+        $counter->resetCols()
+            ->cols(['COUNT(*)']);
+        $actual = $select->__toString();
+        $this->assertSameSql($expect, $actual);
+
+        $expect = 'SELECT
+                COUNT(*)
+            FROM
+                "employee"
+            WHERE
+                "employee"."foo" IS NULL
+        ';
+        $actual = $counter->__toString();
+        $this->assertSameSql($expect, $actual);
+    }
+
     protected function silenceErrors()
     {
         $conn = $this->mapper->getWriteConnection();


### PR DESCRIPTION
This is with respect to issue https://github.com/atlasphp/Atlas.Orm/issues/26 and the comment on  https://github.com/atlasphp/Atlas.Orm/issues/5#issuecomment-220659731 .

When we clone the `MapperSelect` and do something on the cloned object it internally changes the TableSelect of the original one.

```
$select = $this->mapper->select(['foo' => null])->cols(['foo']);
$expect = 'SELECT
        foo
    FROM
        "employee"
    WHERE
        "employee"."foo" IS NULL
';
$counter = clone $select;
$counter->resetCols()
    ->cols(['COUNT(*)']);
```

Will result in 

```
 SELECT
-foo
+COUNT(*)
 FROM
 "employee"
 WHERE
 "employee"."foo" IS NULL
```

To fix the same, we need deep cloning.  Sorry that it took some time to send a PR to address the issue.
