### PR TITLE
Read and write from different connection in the ConnectionLocator

### DIFF
--- a/src/Table/AbstractTable.php
+++ b/src/Table/AbstractTable.php
@@ -69,6 +69,24 @@ abstract class AbstractTable implements TableInterface
 
     /**
      *
+     * The name of the read connection in registry entry.
+     *
+     * @var string
+     *
+     */
+    protected $readConnectionName = NULL;
+
+    /**
+     *
+     * The name of the write connection in registry entry.
+     *
+     * @var string
+     *
+     */
+    protected $writeConnectionName = NULL;
+
+    /**
+     *
      * A memo of the primary key column(s) for calculating identities.
      *
      * @var string|array A string for simple keys; an array for composite keys.
@@ -127,7 +145,7 @@ abstract class AbstractTable implements TableInterface
     public function getReadConnection()
     {
         if (! $this->readConnection) {
-            $this->readConnection = $this->connectionLocator->getRead();
+            $this->readConnection = $this->connectionLocator->getRead($this->readConnectionName);
         }
         return $this->readConnection;
     }
@@ -142,7 +160,7 @@ abstract class AbstractTable implements TableInterface
     public function getWriteConnection()
     {
         if (! $this->writeConnection) {
-            $this->writeConnection = $this->connectionLocator->getWrite();
+            $this->writeConnection = $this->connectionLocator->getWrite($this->writeConnectionName);
         }
         return $this->writeConnection;
     }


### PR DESCRIPTION
Hi Paul,

So there is a question whether we need to support passing the name to the `getReadConnection()` and `getWriteConnection` in `AbstractMapper` and there by to the `AbstractTable` class.

Also I am not sure the best way to write a unit test for this. But I would like to discuss this making a small PR with my limited capabilities.

Thank you.
