### PR TITLE
Rename Table methods in todo

### DIFF
--- a/src/Mapper/AbstractMapper.php
+++ b/src/Mapper/AbstractMapper.php
@@ -252,7 +252,7 @@ abstract class AbstractMapper implements MapperInterface
     public function insert(RecordInterface $record)
     {
         $this->events->beforeInsert($this, $record);
-        $result = $this->table->insert($record->getRow());
+        $result = $this->table->insertRow($record->getRow());
         $this->events->afterInsert($this, $record, $result);
         return $result;
     }
@@ -269,7 +269,7 @@ abstract class AbstractMapper implements MapperInterface
     public function update(RecordInterface $record)
     {
         $this->events->beforeUpdate($this, $record);
-        $result = $this->table->update($record->getRow());
+        $result = $this->table->updateRow($record->getRow());
         $this->events->afterUpdate($this, $record, $result);
         return $result;
     }
@@ -286,7 +286,7 @@ abstract class AbstractMapper implements MapperInterface
     public function delete(RecordInterface $record)
     {
         $this->events->beforeDelete($this, $record);
-        $result = $this->table->delete($record->getRow());
+        $result = $this->table->deleteRow($record->getRow());
         $this->events->afterDelete($this, $record, $result);
         return $result;
     }

--- a/src/Table/AbstractTable.php
+++ b/src/Table/AbstractTable.php
@@ -250,10 +250,10 @@ abstract class AbstractTable implements TableInterface
      * @param RowInterface $row The row to insert.
      *
      */
-    public function insert(RowInterface $row)
+    public function insertRow(RowInterface $row)
     {
         $this->events->beforeInsert($this, $row);
-        $insert = $this->newInsert($row);
+        $insert = $this->insert($row);
         $this->events->modifyInsert($this, $row, $insert);
 
         $connection = $this->getWriteConnection();
@@ -287,10 +287,10 @@ abstract class AbstractTable implements TableInterface
      * @param RowInterface $row The row to update.
      *
      */
-    public function update(RowInterface $row)
+    public function updateRow(RowInterface $row)
     {
         $this->events->beforeUpdate($this, $row);
-        $update = $this->newUpdate($row);
+        $update = $this->update($row);
         $this->events->modifyUpdate($this, $row, $update);
 
         if (! $update->hasCols()) {
@@ -323,10 +323,10 @@ abstract class AbstractTable implements TableInterface
      * @param RowInterface $row The row to delete.
      *
      */
-    public function delete(RowInterface $row)
+    public function deleteRow(RowInterface $row)
     {
         $this->events->beforeDelete($this, $row);
-        $delete = $this->newDelete($row);
+        $delete = $this->delete($row);
         $this->events->modifyDelete($this, $row, $delete);
 
         $connection = $this->getWriteConnection();
@@ -531,7 +531,7 @@ abstract class AbstractTable implements TableInterface
      * @return Insert
      *
      */
-    protected function newInsert(RowInterface $row)
+    protected function insert(RowInterface $row)
     {
         $insert = $this->queryFactory->newInsert();
         $insert->into($this->getName());
@@ -555,7 +555,7 @@ abstract class AbstractTable implements TableInterface
      * @return Update
      *
      */
-    protected function newUpdate(RowInterface $row)
+    protected function update(RowInterface $row)
     {
         $update = $this->queryFactory->newUpdate();
         $update->table($this->getName());
@@ -586,7 +586,7 @@ abstract class AbstractTable implements TableInterface
      * @return Delete
      *
      */
-    protected function newDelete(RowInterface $row)
+    protected function delete(RowInterface $row)
     {
         $delete = $this->queryFactory->newDelete();
         $delete->from($this->getName());

--- a/src/Table/TableInterface.php
+++ b/src/Table/TableInterface.php
@@ -83,7 +83,7 @@ interface TableInterface
      * @param RowInterface $row The row to insert.
      *
      */
-    public function insert(RowInterface $row);
+    public function insertRow(RowInterface $row);
 
     /**
      *
@@ -92,7 +92,7 @@ interface TableInterface
      * @param RowInterface $row The row to update.
      *
      */
-    public function update(RowInterface $row);
+    public function updateRow(RowInterface $row);
 
     /**
      *
@@ -101,7 +101,7 @@ interface TableInterface
      * @param RowInterface $row The row to delete.
      *
      */
-    public function delete(RowInterface $row);
+    public function deleteRow(RowInterface $row);
 
     /**
      *


### PR DESCRIPTION
Hi Paul, 

I was trying to pick up some of the todo stuffs.

Not sure if this is really you are looking for : 

Rename Table::insert(), update(), delete() to insertRow(), updateRow(), deleteRow(), and rename newInsert() to insert() , newUpdate() to update(), newDelete() to delete()

I wonder whether the insert() , update(), delete() etc need to be made public. But I am still not sure how they are executed if the Query objects are exposed.

Probably this may not be the PR you are looking for :-) .
