### PR TITLE
getMock is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ php:
 before_script:
   - composer self-update
   - composer install
+  - wget https://phar.phpunit.de/phpunit.phar
 script:
-  - phpunit --coverage-clover=coverage.clover
+  - php phpunit.phar --coverage-clover=coverage.clover
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/tests/Mapper/MapperSelectTest.php
+++ b/tests/Mapper/MapperSelectTest.php
@@ -37,7 +37,7 @@ class MapperSelectTest extends \PHPUnit_Framework_TestCase
         $select = $queryFactory->newSelect()->from('employee');
 
         $this->select = new MapperSelect(
-            $this->getMock('Atlas\Orm\Mapper\MapperInterface'),
+            $this->createMock('Atlas\Orm\Mapper\MapperInterface'),
             new TableSelect($table, $select)
         );
     }

--- a/tests/Mapper/RecordSetTest.php
+++ b/tests/Mapper/RecordSetTest.php
@@ -21,8 +21,8 @@ class RecordSetTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $this->related = new Related([
-            'zim' => $this->getMock(RecordInterface::CLASS),
-            'irk' => $this->getMock(RecordSetInterface::CLASS),
+            'zim' => $this->createMock(RecordInterface::CLASS),
+            'irk' => $this->createMock(RecordSetInterface::CLASS),
         ]);
 
         $this->record = new Record('FakeMapper', $this->row, $this->related);

--- a/tests/Mapper/RecordTest.php
+++ b/tests/Mapper/RecordTest.php
@@ -15,8 +15,8 @@ class RecordTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->zim = $this->getMock(RecordInterface::CLASS);
-        $this->irk = $this->getMock(RecordSetInterface::CLASS);
+        $this->zim = $this->createMock(RecordInterface::CLASS);
+        $this->irk = $this->createMock(RecordSetInterface::CLASS);
 
         $this->row = new Row([
             'id' => '1',
@@ -66,7 +66,7 @@ class RecordTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('barbar', $this->row->foo);
 
         // related
-        $newZim = $this->getMock(RecordInterface::CLASS);
+        $newZim = $this->createMock(RecordInterface::CLASS);
         $this->record->zim = $newZim;
         $this->assertSame($newZim, $this->record->zim);
 
@@ -127,10 +127,10 @@ class RecordTest extends \PHPUnit_Framework_TestCase
 
     public function testSet()
     {
-        $newZim = $this->getMock(RecordInterface::CLASS);
+        $newZim = $this->createMock(RecordInterface::CLASS);
         $newZim->method('getArrayCopy')->willReturn('gir');
 
-        $newIrk = $this->getMock(RecordSetInterface::CLASS);
+        $newIrk = $this->createMock(RecordSetInterface::CLASS);
         $newIrk->method('getArrayCopy')->willReturn('doom');
 
         $this->record->set([

--- a/tests/Mapper/RelatedTest.php
+++ b/tests/Mapper/RelatedTest.php
@@ -11,8 +11,8 @@ class RelatedTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->zim = $this->getMock(RecordInterface::CLASS);
-        $this->irk = $this->getMock(RecordSetInterface::CLASS);
+        $this->zim = $this->createMock(RecordInterface::CLASS);
+        $this->irk = $this->createMock(RecordSetInterface::CLASS);
         $this->related = new Related([
             'zim' => $this->zim,
             'irk' => $this->irk,
@@ -34,7 +34,7 @@ class RelatedTest extends \PHPUnit_Framework_TestCase
 
     public function test__set()
     {
-        $newZim = $this->getMock(RecordInterface::CLASS);
+        $newZim = $this->createMock(RecordInterface::CLASS);
 
         // related
         $this->related->zim = $newZim;

--- a/tests/WorkTest.php
+++ b/tests/WorkTest.php
@@ -19,8 +19,8 @@ class WorkTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $related = new Related([
-            'zim' => $this->getMock(RecordInterface::CLASS),
-            'irk' => $this->getMock(RecordSetInterface::CLASS),
+            'zim' => $this->createMock(RecordInterface::CLASS),
+            'irk' => $this->createMock(RecordSetInterface::CLASS),
         ]);
 
         $record = new Record('FakeMapper', $row, $related);


### PR DESCRIPTION
PHPUnit 5.5+ deprecate message is thrown to use `createMock` or `getMockBuilder` instead of getMock .

See travis build https://travis-ci.org/atlasphp/Atlas.Orm/jobs/168678156 
