### PR TITLE
PHPUnit 5.5+ deprecates getMock and message is thrown 

### DIFF
--- a/tests/Mapper/MapperSelectTest.php
+++ b/tests/Mapper/MapperSelectTest.php
@@ -10,8 +10,9 @@ use Aura\Sql\ConnectionLocator;
 use Aura\Sql\ExtendedPdo;
 use Aura\SqlQuery\QueryFactory;
 use Atlas\Orm\DataSource\Employee\EmployeeTable;
+use Atlas\Orm\TestCase;
 
-class MapperSelectTest extends \PHPUnit_Framework_TestCase
+class MapperSelectTest extends TestCase
 {
     use Assertions;
 
@@ -37,7 +38,7 @@ class MapperSelectTest extends \PHPUnit_Framework_TestCase
         $select = $queryFactory->newSelect()->from('employee');
 
         $this->select = new MapperSelect(
-            $this->getMock('Atlas\Orm\Mapper\MapperInterface'),
+            $this->getMockFromBuilder('Atlas\Orm\Mapper\MapperInterface'),
             new TableSelect($table, $select)
         );
     }

--- a/tests/Mapper/RecordSetTest.php
+++ b/tests/Mapper/RecordSetTest.php
@@ -3,9 +3,10 @@ namespace Atlas\Orm\Mapper;
 
 use Atlas\Orm\Table\Row;
 use Atlas\Orm\Table\Primary;
+use Atlas\Orm\TestCase;
 use StdClass;
 
-class RecordSetTest extends \PHPUnit_Framework_TestCase
+class RecordSetTest extends TestCase
 {
     protected $row;
     protected $related;
@@ -21,8 +22,8 @@ class RecordSetTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $this->related = new Related([
-            'zim' => $this->getMock(RecordInterface::CLASS),
-            'irk' => $this->getMock(RecordSetInterface::CLASS),
+            'zim' => $this->getMockFromBuilder(RecordInterface::CLASS),
+            'irk' => $this->getMockFromBuilder(RecordSetInterface::CLASS),
         ]);
 
         $this->record = new Record('FakeMapper', $this->row, $this->related);

--- a/tests/Mapper/RecordTest.php
+++ b/tests/Mapper/RecordTest.php
@@ -4,8 +4,9 @@ namespace Atlas\Orm\Mapper;
 use Atlas\Orm\Exception;
 use Atlas\Orm\Table\Row;
 use Atlas\Orm\Table\Primary;
+use Atlas\Orm\TestCase;
 
-class RecordTest extends \PHPUnit_Framework_TestCase
+class RecordTest extends TestCase
 {
     protected $row;
     protected $related;
@@ -15,8 +16,8 @@ class RecordTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->zim = $this->getMock(RecordInterface::CLASS);
-        $this->irk = $this->getMock(RecordSetInterface::CLASS);
+        $this->zim = $this->getMockFromBuilder(RecordInterface::CLASS);
+        $this->irk = $this->getMockFromBuilder(RecordSetInterface::CLASS);
 
         $this->row = new Row([
             'id' => '1',
@@ -66,7 +67,7 @@ class RecordTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('barbar', $this->row->foo);
 
         // related
-        $newZim = $this->getMock(RecordInterface::CLASS);
+        $newZim = $this->getMockFromBuilder(RecordInterface::CLASS);
         $this->record->zim = $newZim;
         $this->assertSame($newZim, $this->record->zim);
 
@@ -127,10 +128,10 @@ class RecordTest extends \PHPUnit_Framework_TestCase
 
     public function testSet()
     {
-        $newZim = $this->getMock(RecordInterface::CLASS);
+        $newZim = $this->getMockFromBuilder(RecordInterface::CLASS);
         $newZim->method('getArrayCopy')->willReturn('gir');
 
-        $newIrk = $this->getMock(RecordSetInterface::CLASS);
+        $newIrk = $this->getMockFromBuilder(RecordSetInterface::CLASS);
         $newIrk->method('getArrayCopy')->willReturn('doom');
 
         $this->record->set([

--- a/tests/Mapper/RelatedTest.php
+++ b/tests/Mapper/RelatedTest.php
@@ -2,8 +2,9 @@
 namespace Atlas\Orm\Mapper;
 
 use Atlas\Orm\Exception;
+use Atlas\Orm\TestCase;
 
-class RelatedTest extends \PHPUnit_Framework_TestCase
+class RelatedTest extends TestCase
 {
     protected $zim;
     protected $irk;
@@ -11,8 +12,8 @@ class RelatedTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->zim = $this->getMock(RecordInterface::CLASS);
-        $this->irk = $this->getMock(RecordSetInterface::CLASS);
+        $this->zim = $this->getMockFromBuilder(RecordInterface::CLASS);
+        $this->irk = $this->getMockFromBuilder(RecordSetInterface::CLASS);
         $this->related = new Related([
             'zim' => $this->zim,
             'irk' => $this->irk,
@@ -34,7 +35,7 @@ class RelatedTest extends \PHPUnit_Framework_TestCase
 
     public function test__set()
     {
-        $newZim = $this->getMock(RecordInterface::CLASS);
+        $newZim = $this->getMockFromBuilder(RecordInterface::CLASS);
 
         // related
         $this->related->zim = $newZim;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,16 @@
+<?php
+namespace Atlas\Orm;
+
+class TestCase extends \PHPUnit_Framework_TestCase
+{
+    protected function getMockFromBuilder($class)
+    {
+        $mock = $this->getMockBuilder($class)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->getMock();
+
+        return $mock;
+    }
+}

--- a/tests/WorkTest.php
+++ b/tests/WorkTest.php
@@ -8,7 +8,7 @@ use Atlas\Orm\Mapper\Related;
 use Atlas\Orm\Table\Primary;
 use Atlas\Orm\Table\Row;
 
-class WorkTest extends \PHPUnit_Framework_TestCase
+class WorkTest extends TestCase
 {
     public function test__invoke_reInvoke()
     {
@@ -19,8 +19,8 @@ class WorkTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $related = new Related([
-            'zim' => $this->getMock(RecordInterface::CLASS),
-            'irk' => $this->getMock(RecordSetInterface::CLASS),
+            'zim' => $this->getMockFromBuilder(RecordInterface::CLASS),
+            'irk' => $this->getMockFromBuilder(RecordSetInterface::CLASS),
         ]);
 
         $record = new Record('FakeMapper', $row, $related);


### PR DESCRIPTION
to use createMock or getMockBuilder.

As travis run phpunit 4.8 on 5.6 and hhvm, a TestCase class is create which have a getMockFromBuilder method.

Alternatively we could run wget on travis and run php phpunit.phar.

The PR https://github.com/atlasphp/Atlas.Orm/pull/41 is addressed to use the same . You don't need to merge both. Only one according to what you think is best.
