### PR TITLE
Adding support for nested arrays instead of anonymous functions in with

### DIFF
--- a/src/Relationship/Relationships.php
+++ b/src/Relationship/Relationships.php
@@ -316,6 +316,10 @@ class Relationships
         foreach ($spec as $key => $val) {
             if (is_int($key)) {
                 $with[$val] = null;
+            } elseif (is_array($val)) {
+                $with[$key] = function ($select) use ($val) {
+                    $select->with($val);
+                };
             } else {
                 $with[$key] = $val;
             }

--- a/tests/AtlasTest.php
+++ b/tests/AtlasTest.php
@@ -175,6 +175,25 @@ class AtlasTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->expectRecord, $actual->getArrayCopy());
     }
 
+    public function testSelect_fetchRecordNestedArrayWith()
+    {
+        $actual = $this->atlas
+            ->select(ThreadMapper::CLASS)
+            ->where('thread_id < ?', 2)
+            ->with([
+                'author', // manyToOne
+                'summary', // oneToOne
+                'replies' => [
+                    'author',
+                ], // oneToMany
+                'taggings', // oneToMany,
+                'tags', // manyToMany
+            ])
+            ->fetchRecord();
+
+        $this->assertSame($this->expectRecord, $actual->getArrayCopy());
+    }
+
     public function testSelect_fetchRecordSet()
     {
         $actual = $this->atlas


### PR DESCRIPTION
This small tweak allows for an alternate syntax for `with` relationships.

Instead of anonymous functions:

```php
$entity = $this->atlas->fetchRecord(
    CreatorMapper::class,
    $id,
    [
        'short_story_creators' => function ($shortfictions) {
            $shortfictions->with([
                'short_story' => function ($shortfiction) {
                    $shortfiction->with([
                        'game_line',
                        'fiction_book',
                        'magazine_issue' => function ($magazine) {
                            $magazine->with([
                                'magazine_title',
                            ]);
                        },
                        'rpg_book',
                    ]);
                },
                'credit',
            ]);
        },
    ]
);
```

You could use a nested array:

```php
$entity = $this->atlas->fetchRecord(
    CreatorMapper::class,
    $id,
    [
        'short_story_creators' => [
            'short_story' => [
                'game_line',
                'fiction_book',
                'magazine_issue' => [
                    'magazine_title',
                ],
                'rpg_book',
            ],
            'credit',
        ],
    ]
);
```

This seems like it would be far more readable without removing any existing functionality or breaking backward compatibility.