### PR TITLE
Fix: Make sure array is not callable in with spec

### DIFF
--- a/src/Relationship/Relationships.php
+++ b/src/Relationship/Relationships.php
@@ -316,7 +316,7 @@ class Relationships
         foreach ($spec as $key => $val) {
             if (is_int($key)) {
                 $with[$val] = null;
-            } elseif (is_array($val)) {
+            } elseif (is_array($val) && ! is_callable($val)) {
                 $with[$key] = function ($select) use ($val) {
                     $select->with($val);
                 };

--- a/tests/AtlasTest.php
+++ b/tests/AtlasTest.php
@@ -194,6 +194,24 @@ class AtlasTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->expectRecord, $actual->getArrayCopy());
     }
 
+    public function testSelect_fetchRecordCallableArrayWith()
+    {
+        $with = new Fake\CallableWithObject;
+        $actual = $this->atlas
+            ->select(ThreadMapper::CLASS)
+            ->where('thread_id < ?', 2)
+            ->with([
+                'author', // manyToOne
+                'summary', // oneToOne
+                'replies' => [$with, 'replies'], // oneToMany
+                'taggings', // oneToMany,
+                'tags', // manyToMany
+            ])
+            ->fetchRecord();
+
+        $this->assertSame($this->expectRecord, $actual->getArrayCopy());
+    }
+
     public function testSelect_fetchRecordSet()
     {
         $actual = $this->atlas

--- a/tests/Fake/CallableWithObject.php
+++ b/tests/Fake/CallableWithObject.php
@@ -1,0 +1,12 @@
+<?php
+namespace Atlas\Orm\Fake;
+
+class CallableWithObject
+{
+
+    public function replies($query)
+    {
+        $query->with(['author']);
+    }
+
+}


### PR DESCRIPTION
Addition of #44 broke ability to pass a callable array to the with spec.
This checks that the array is not callable first.