### PR TITLE
Remove trailing slash in link to Mehdi Khalili's post

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ of a project. Even so, the Row, Record, and RecordSet objects are disconnected
 from the database, which should make the refactoring process a lot cleaner than
 with Active Record.
 
-[mkap]: http://www.mehdi-khalili.com/orm-anti-patterns-part-4-persistence-domain-model/
+[mkap]: http://www.mehdi-khalili.com/orm-anti-patterns-part-4-persistence-domain-model
 
 Other rationalizations, essentially based around things I *do not* want in an
 ORM:


### PR DESCRIPTION
The link to http://www.mehdi-khalili.com/orm-anti-patterns-part-4-persistence-domain-model had a slash at the end, which resulted in a 404 page not found error