### PR TITLE
Fixes #58

### DIFF
--- a/src/Relationship/AbstractRelationship.php
+++ b/src/Relationship/AbstractRelationship.php
@@ -363,6 +363,10 @@ abstract class AbstractRelationship implements RelationshipInterface
      */
     protected function fetchForeignRecords(array $records, $custom)
     {
+        if (! $records) {
+            return [];
+        }
+
         $select = $this->foreignSelect($records);
         if ($custom) {
             $custom($select);


### PR DESCRIPTION
In AbstractRelationship::fetchForeignRecords(), if there are no $reco…rds to match against, pre-emptively return an empty array instead of issuing an empty IN() query.

Fixes #58.