### PR TITLE
Add option to use a ConnectionLocator as argument for the Container

### DIFF
--- a/src/AtlasContainer.php
+++ b/src/AtlasContainer.php
@@ -131,6 +131,11 @@ class AtlasContainer
     {
         switch (true) {
 
+            case $args[0] instanceof ConnectionLocator:
+                $this->connectionLocator = $args[0];
+
+                return $this->connectionLocator->getDefault()->getAttribute(PDO::ATTR_DRIVER_NAME);
+
             case $args[0] instanceof ExtendedPdo:
                 $extendedPdo = $args[0];
                 $default = function () use ($extendedPdo) {

--- a/tests/AtlasContainerTest.php
+++ b/tests/AtlasContainerTest.php
@@ -10,6 +10,7 @@ use Atlas\Orm\DataSource\Summary\SummaryTable;
 use Atlas\Orm\DataSource\Tag\TagMapper;
 use Atlas\Orm\DataSource\Thread\ThreadMapper;
 use Atlas\Orm\DataSource\Tagging\TaggingMapper;
+use Aura\Sql\ConnectionLocator;
 use Aura\Sql\ExtendedPdo;
 
 class AtlasContainerTest extends \PHPUnit_Framework_TestCase
@@ -57,5 +58,15 @@ class AtlasContainerTest extends \PHPUnit_Framework_TestCase
             'FooMapper does not exist'
         );
         $this->atlasContainer->setMapper('FooMapper');
+    }
+
+    public function testCustomConnectionLocator()
+    {
+        $locator = new ConnectionLocator(function() {
+            return new ExtendedPdo('sqlite::memory:');
+        });
+        $atlasContainer = new AtlasContainer($locator);
+
+        $this->assertEquals($locator, $atlasContainer->getConnectionLocator());
     }
 }


### PR DESCRIPTION
Hi 

I added an option to the atlas container to allow me to pass in a pre configured ConnectionLocator.

