### PR TITLE
Added auto-casting feature

### DIFF
--- a/src/Table/AbstractTable.php
+++ b/src/Table/AbstractTable.php
@@ -536,9 +536,14 @@ abstract class AbstractTable implements TableInterface
     public function newRow(array $cols = [])
     {
         $colNames = $this->getColNames();
+        $colMap = $this->getCols();
         foreach ($cols as $col => $val) {
             if (! in_array($col, $colNames)) {
                 unset($cols[$col]);
+            }
+
+            if (isset($colMap[$col]) && property_exists($colMap[$col], 'mapTo')) {
+                settype($cols[$col], $colMap[$col]->mapTo);
             }
         }
         $cols = array_merge($this->getColDefaults(), $cols);

--- a/src/Table/AbstractTable.php
+++ b/src/Table/AbstractTable.php
@@ -542,6 +542,12 @@ abstract class AbstractTable implements TableInterface
                 unset($cols[$col]);
             }
 
+            // If property is null and is nullable continue
+            if ($val === null && property_exists($colMap[$col], 'notnull') && $colMap[$col]->notnull === true) {
+                continue;
+            }
+
+            // Cast to a specified type if mapTo has been specified
             if (isset($colMap[$col]) && property_exists($colMap[$col], 'mapTo')) {
                 settype($cols[$col], $colMap[$col]->mapTo);
             }

--- a/tests/AtlasCompositeTest.php
+++ b/tests/AtlasCompositeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Atlas\Orm;
 
 use Atlas\Orm\DataSource\Course\CourseMapper;
@@ -6,7 +7,6 @@ use Atlas\Orm\DataSource\Degree\DegreeMapper;
 use Atlas\Orm\DataSource\Enrollment\EnrollmentMapper;
 use Atlas\Orm\DataSource\Gpa\GpaMapper;
 use Atlas\Orm\DataSource\Student\StudentMapper;
-use Aura\Sql\ExtendedPdo;
 
 class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
 {
@@ -82,7 +82,7 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
         )->getArrayCopy();
 
         foreach ($this->expectRecordSet as $i => $expect) {
-            $this->assertSame($expect, $actual[$i], "record $i not the same");
+            $this->assertEquals($expect, $actual[$i], "record $i not the same");
         }
     }
 
@@ -101,7 +101,7 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
         )->getArrayCopy();
 
         foreach ($this->expectRecordSet as $i => $expect) {
-            $this->assertSame($expect, $actual[$i], "record $i not the same");
+            $this->assertEquals($expect, $actual[$i], "record $i not the same");
         }
     }
 
@@ -118,7 +118,7 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
             ])
             ->fetchRecord();
 
-        $this->assertSame($this->expectRecord, $actual->getArrayCopy());
+        $this->assertEquals($this->expectRecord, $actual->getArrayCopy());
     }
 
     public function testSelect_fetchRecordSet()
@@ -136,7 +136,7 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
             ->getArrayCopy();
 
         foreach ($this->expectRecordSet as $i => $expect) {
-            $this->assertSame($expect, $actual[$i], "record $i not the same");
+            $this->assertEquals($expect, $actual[$i], "record $i not the same");
         }
     }
 
@@ -225,9 +225,9 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
                 'student_fn' => 'Anna',
                 'student_ln' => 'Alpha',
                 'course_subject' => 'ENGL',
-                'course_number' => '100',
-                'grade' => '65',
-                'points' => '1',
+                'course_number' => 100,
+                'grade' => 65,
+                'points' => 1,
                 'course' => NULL,
                 'student' => NULL,
             ]
@@ -244,7 +244,7 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
         'gpa' => [
             'student_fn' => 'Anna',
             'student_ln' => 'Alpha',
-            'gpa' => '1.333',
+            'gpa' => 1.333,
             'student' => null,
         ],
         'degree' => [
@@ -258,9 +258,9 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
                 'student_fn' => 'Anna',
                 'student_ln' => 'Alpha',
                 'course_subject' => 'ENGL',
-                'course_number' => '100',
-                'grade' => '65',
-                'points' => '1',
+                'course_number' => 100,
+                'grade' => 65,
+                'points' => 1,
                 'course' => null,
                 'student' => null,
             ],
@@ -268,9 +268,9 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
                 'student_fn' => 'Anna',
                 'student_ln' => 'Alpha',
                 'course_subject' => 'HIST',
-                'course_number' => '100',
-                'grade' => '68',
-                'points' => '1',
+                'course_number' => 100,
+                'grade' => 68,
+                'points' => 1,
                 'course' => null,
                 'student' => null,
             ],
@@ -278,9 +278,9 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
                 'student_fn' => 'Anna',
                 'student_ln' => 'Alpha',
                 'course_subject' => 'MATH',
-                'course_number' => '100',
-                'grade' => '71',
-                'points' => '2',
+                'course_number' => 100,
+                'grade' => 71,
+                'points' => 2,
                 'course' => null,
                 'student' => null,
             ],
@@ -288,21 +288,21 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
         'courses' => [
             0 => [
                 'course_subject' => 'ENGL',
-                'course_number' => '100',
+                'course_number' => 100,
                 'title' => 'Composition',
                 'enrollments' => null,
                 'students' => null,
             ],
             1 => [
                 'course_subject' => 'HIST',
-                'course_number' => '100',
+                'course_number' => 100,
                 'title' => 'World History',
                 'enrollments' => null,
                 'students' => null,
             ],
             2 => [
                 'course_subject' => 'MATH',
-                'course_number' => '100',
+                'course_number' => 100,
                 'title' => 'Algebra',
                 'enrollments' => null,
                 'students' => null,
@@ -320,7 +320,7 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
             'gpa' => [
                 'student_fn' => 'Anna',
                 'student_ln' => 'Alpha',
-                'gpa' => '1.333',
+                'gpa' => 1.333,
                 'student' => NULL,
             ],
             'degree' => [
@@ -334,9 +334,9 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
                     'student_fn' => 'Anna',
                     'student_ln' => 'Alpha',
                     'course_subject' => 'ENGL',
-                    'course_number' => '100',
-                    'grade' => '65',
-                    'points' => '1',
+                    'course_number' => 100,
+                    'grade' => 65,
+                    'points' => 1,
                     'course' => NULL,
                     'student' => NULL,
                 ],
@@ -344,9 +344,9 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
                     'student_fn' => 'Anna',
                     'student_ln' => 'Alpha',
                     'course_subject' => 'HIST',
-                    'course_number' => '100',
-                    'grade' => '68',
-                    'points' => '1',
+                    'course_number' => 100,
+                    'grade' => 68,
+                    'points' => 1,
                     'course' => NULL,
                     'student' => NULL,
                 ],
@@ -354,9 +354,9 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
                     'student_fn' => 'Anna',
                     'student_ln' => 'Alpha',
                     'course_subject' => 'MATH',
-                    'course_number' => '100',
-                    'grade' => '71',
-                    'points' => '2',
+                    'course_number' => 100,
+                    'grade' => 71,
+                    'points' => 2,
                     'course' => NULL,
                     'student' => NULL,
                 ],
@@ -364,21 +364,21 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
             'courses' => [
                 0 => [
                     'course_subject' => 'ENGL',
-                    'course_number' => '100',
+                    'course_number' => 100,
                     'title' => 'Composition',
                     'enrollments' => NULL,
                     'students' => NULL,
                 ],
                 1 => [
                     'course_subject' => 'HIST',
-                    'course_number' => '100',
+                    'course_number' => 100,
                     'title' => 'World History',
                     'enrollments' => NULL,
                     'students' => NULL,
                 ],
                 2 => [
                     'course_subject' => 'MATH',
-                    'course_number' => '100',
+                    'course_number' => 100,
                     'title' => 'Algebra',
                     'enrollments' => NULL,
                     'students' => NULL,
@@ -394,7 +394,7 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
             'gpa' => [
                 'student_fn' => 'Betty',
                 'student_ln' => 'Beta',
-                'gpa' => '1.667',
+                'gpa' => 1.667,
                 'student' => NULL,
             ],
             'degree' => [
@@ -408,9 +408,9 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
                     'student_fn' => 'Betty',
                     'student_ln' => 'Beta',
                     'course_subject' => 'ENGL',
-                    'course_number' => '200',
-                    'grade' => '74',
-                    'points' => '2',
+                    'course_number' => 200,
+                    'grade' => 74,
+                    'points' => 2,
                     'course' => NULL,
                     'student' => NULL,
                 ],
@@ -418,9 +418,9 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
                     'student_fn' => 'Betty',
                     'student_ln' => 'Beta',
                     'course_subject' => 'HIST',
-                    'course_number' => '100',
-                    'grade' => '68',
-                    'points' => '1',
+                    'course_number' => 100,
+                    'grade' => 68,
+                    'points' => 1,
                     'course' => NULL,
                     'student' => NULL,
                 ],
@@ -428,9 +428,9 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
                     'student_fn' => 'Betty',
                     'student_ln' => 'Beta',
                     'course_subject' => 'MATH',
-                    'course_number' => '100',
-                    'grade' => '71',
-                    'points' => '2',
+                    'course_number' => 100,
+                    'grade' => 71,
+                    'points' => 2,
                     'course' => NULL,
                     'student' => NULL,
                 ],
@@ -438,21 +438,21 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
             'courses' => [
                 0 => [
                     'course_subject' => 'ENGL',
-                    'course_number' => '200',
+                    'course_number' => 200,
                     'title' => 'Creative Writing',
                     'enrollments' => NULL,
                     'students' => NULL,
                 ],
                 1 => [
                     'course_subject' => 'HIST',
-                    'course_number' => '100',
+                    'course_number' => 100,
                     'title' => 'World History',
                     'enrollments' => NULL,
                     'students' => NULL,
                 ],
                 2 => [
                     'course_subject' => 'MATH',
-                    'course_number' => '100',
+                    'course_number' => 100,
                     'title' => 'Algebra',
                     'enrollments' => NULL,
                     'students' => NULL,
@@ -482,9 +482,9 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
                     'student_fn' => 'Clara',
                     'student_ln' => 'Clark',
                     'course_subject' => 'ENGL',
-                    'course_number' => '200',
-                    'grade' => '74',
-                    'points' => '2',
+                    'course_number' => 200,
+                    'grade' => 74,
+                    'points' => 2,
                     'course' => NULL,
                     'student' => NULL,
                 ],
@@ -492,9 +492,9 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
                     'student_fn' => 'Clara',
                     'student_ln' => 'Clark',
                     'course_subject' => 'HIST',
-                    'course_number' => '200',
-                    'grade' => '77',
-                    'points' => '2',
+                    'course_number' => 200,
+                    'grade' => 77,
+                    'points' => 2,
                     'course' => NULL,
                     'student' => NULL,
                 ],
@@ -502,9 +502,9 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
                     'student_fn' => 'Clara',
                     'student_ln' => 'Clark',
                     'course_subject' => 'MATH',
-                    'course_number' => '100',
-                    'grade' => '71',
-                    'points' => '2',
+                    'course_number' => 100,
+                    'grade' => 71,
+                    'points' => 2,
                     'course' => NULL,
                     'student' => NULL,
                 ],
@@ -512,21 +512,21 @@ class AtlasCompositeTest extends \PHPUnit_Framework_TestCase
             'courses' => [
                 0 => [
                     'course_subject' => 'ENGL',
-                    'course_number' => '200',
+                    'course_number' => 200,
                     'title' => 'Creative Writing',
                     'enrollments' => NULL,
                     'students' => NULL,
                 ],
                 1 => [
                     'course_subject' => 'HIST',
-                    'course_number' => '200',
+                    'course_number' => 200,
                     'title' => 'US History',
                     'enrollments' => NULL,
                     'students' => NULL,
                 ],
                 2 => [
                     'course_subject' => 'MATH',
-                    'course_number' => '100',
+                    'course_number' => 100,
                     'title' => 'Algebra',
                     'enrollments' => NULL,
                     'students' => NULL,

--- a/tests/AtlasTest.php
+++ b/tests/AtlasTest.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace Atlas\Orm;
 
 use Atlas\Orm\DataSource\Author\AuthorMapper;
 use Atlas\Orm\DataSource\Reply\ReplyMapper;
 use Atlas\Orm\DataSource\Reply\ReplyRecord;
-use Atlas\Orm\DataSource\Reply\ReplyRecordSet;
 use Atlas\Orm\DataSource\Summary\SummaryMapper;
-use Atlas\Orm\DataSource\Summary\SummaryTable;
 use Atlas\Orm\DataSource\Tag\TagMapper;
 use Atlas\Orm\DataSource\Tagging\TaggingMapper;
 use Atlas\Orm\DataSource\Thread\ThreadMapper;
@@ -14,7 +13,6 @@ use Atlas\Orm\DataSource\Thread\ThreadRecord;
 use Atlas\Orm\DataSource\Thread\ThreadRecordSet;
 use Atlas\Orm\Mapper\Record;
 use Atlas\Orm\Mapper\RecordSet;
-use Aura\Sql\ExtendedPdo;
 use Aura\Sql\Profiler;
 
 class AtlasTest extends \PHPUnit_Framework_TestCase
@@ -293,7 +291,8 @@ class AtlasTest extends \PHPUnit_Framework_TestCase
             ->fetchOne(
                 "SELECT * FROM authors WHERE name = 'Annabelle'"
             );
-        $this->assertSame($expect, $actual);
+        // Will assert equals but not same because the 'author_id' has been casted in integer
+        $this->assertEquals($expect, $actual);
 
         // try to update again, should be a no-op because there are no changes
         $this->assertFalse($this->atlas->update($author));
@@ -341,7 +340,7 @@ class AtlasTest extends \PHPUnit_Framework_TestCase
     {
         // plain old primary value
         $actual = $this->atlas->fetchRecord(AuthorMapper::CLASS, 1);
-        $this->assertSame('1', $actual->author_id);
+        $this->assertSame(1, $actual->author_id);
 
         // primary embedded in array
         $actual = $this->atlas->fetchRecord(AuthorMapper::CLASS, [
@@ -349,7 +348,7 @@ class AtlasTest extends \PHPUnit_Framework_TestCase
             'foo' => 'bar',
             'baz' => 'dib'
         ]);
-        $this->assertSame('2', $actual->author_id);
+        $this->assertSame(2, $actual->author_id);
 
         // not a scalar
         $this->setExpectedException(
@@ -422,79 +421,79 @@ ORDER BY
     }
 
     protected $expectRecord = [
-        'thread_id' => '1',
-        'author_id' => '1',
+        'thread_id' => 1,
+        'author_id' => 1,
         'subject' => 'Thread subject 1',
         'body' => 'Thread body 1',
         'author' => [
-            'author_id' => '1',
+            'author_id' => 1,
             'name' => 'Anna',
             'replies' => null,
             'threads' => null,
         ],
         'summary' => [
-            'summary_id' => '1',
-            'thread_id' => '1',
-            'reply_count' => '5',
-            'view_count' => '0',
+            'summary_id' => 1,
+            'thread_id' => 1,
+            'reply_count' => 5,
+            'view_count' => 0,
             'thread' => null,
         ],
         'replies' => [
             0 => [
-                'reply_id' => '1',
-                'thread_id' => '1',
-                'author_id' => '2',
+                'reply_id' => 1,
+                'thread_id' => 1,
+                'author_id' => 2,
                 'body' => 'Reply 1 on thread 1',
                 'author' => [
-                    'author_id' => '2',
+                    'author_id' => 2,
                     'name' => 'Betty',
                     'replies' => null,
                     'threads' => null,
                 ],
             ],
             1 => [
-                'reply_id' => '2',
-                'thread_id' => '1',
-                'author_id' => '3',
+                'reply_id' => 2,
+                'thread_id' => 1,
+                'author_id' => 3,
                 'body' => 'Reply 2 on thread 1',
                 'author' => [
-                    'author_id' => '3',
+                    'author_id' => 3,
                     'name' => 'Clara',
                     'replies' => null,
                     'threads' => null,
                 ],
             ],
             2 => [
-                'reply_id' => '3',
-                'thread_id' => '1',
-                'author_id' => '4',
+                'reply_id' => 3,
+                'thread_id' => 1,
+                'author_id' => 4,
                 'body' => 'Reply 3 on thread 1',
                 'author' => [
-                    'author_id' => '4',
+                    'author_id' => 4,
                     'name' => 'Donna',
                     'replies' => null,
                     'threads' => null,
                 ],
             ],
             3 => [
-                'reply_id' => '4',
-                'thread_id' => '1',
-                'author_id' => '5',
+                'reply_id' => 4,
+                'thread_id' => 1,
+                'author_id' => 5,
                 'body' => 'Reply 4 on thread 1',
                 'author' => [
-                    'author_id' => '5',
+                    'author_id' => 5,
                     'name' => 'Edna',
                     'replies' => null,
                     'threads' => null,
                 ],
             ],
             4 => [
-                'reply_id' => '5',
-                'thread_id' => '1',
-                'author_id' => '6',
+                'reply_id' => 5,
+                'thread_id' => 1,
+                'author_id' => 6,
                 'body' => 'Reply 5 on thread 1',
                 'author' => [
-                    'author_id' => '6',
+                    'author_id' => 6,
                     'name' => 'Fiona',
                     'replies' => null,
                     'threads' => null,
@@ -503,42 +502,42 @@ ORDER BY
         ],
         'taggings' => [
             0 => [
-                'tagging_id' => '1',
-                'thread_id' => '1',
-                'tag_id' => '1',
+                'tagging_id' => 1,
+                'thread_id' => 1,
+                'tag_id' => 1,
                 'thread' => null,
                 'tag' => null,
             ],
             1 => [
-                'tagging_id' => '2',
-                'thread_id' => '1',
-                'tag_id' => '2',
+                'tagging_id' => 2,
+                'thread_id' => 1,
+                'tag_id' => 2,
                 'thread' => null,
                 'tag' => null,
             ],
             2 => [
-                'tagging_id' => '3',
-                'thread_id' => '1',
-                'tag_id' => '3',
+                'tagging_id' => 3,
+                'thread_id' => 1,
+                'tag_id' => 3,
                 'thread' => null,
                 'tag' => null,
             ],
         ],
         'tags' => [
             0 => [
-                'tag_id' => '1',
+                'tag_id' => 1,
                 'name' => 'foo',
                 'taggings' => null,
                 'threads' => null,
             ],
             1 => [
-                'tag_id' => '2',
+                'tag_id' => 2,
                 'name' => 'bar',
                 'taggings' => null,
                 'threads' => null,
             ],
             2 => [
-                'tag_id' => '3',
+                'tag_id' => 3,
                 'name' => 'baz',
                 'taggings' => null,
                 'threads' => null,
@@ -548,79 +547,79 @@ ORDER BY
 
     protected $expectRecordSet = [
         0 => [
-            'thread_id' => '1',
-            'author_id' => '1',
+            'thread_id' => 1,
+            'author_id' => 1,
             'subject' => 'Thread subject 1',
             'body' => 'Thread body 1',
             'author' => [
-                'author_id' => '1',
+                'author_id' => 1,
                 'name' => 'Anna',
                 'replies' => null,
                 'threads' => null,
             ],
             'summary' => [
-                'summary_id' => '1',
-                'thread_id' => '1',
-                'reply_count' => '5',
-                'view_count' => '0',
+                'summary_id' => 1,
+                'thread_id' => 1,
+                'reply_count' => 5,
+                'view_count' => 0,
                 'thread' => null,
             ],
             'replies' => [
                 0 => [
-                    'reply_id' => '1',
-                    'thread_id' => '1',
-                    'author_id' => '2',
+                    'reply_id' => 1,
+                    'thread_id' => 1,
+                    'author_id' => 2,
                     'body' => 'Reply 1 on thread 1',
                     'author' => [
-                        'author_id' => '2',
+                        'author_id' => 2,
                         'name' => 'Betty',
                         'replies' => null,
                         'threads' => null,
                     ],
                 ],
                 1 => [
-                    'reply_id' => '2',
-                    'thread_id' => '1',
-                    'author_id' => '3',
+                    'reply_id' => 2,
+                    'thread_id' => 1,
+                    'author_id' => 3,
                     'body' => 'Reply 2 on thread 1',
                     'author' => [
-                        'author_id' => '3',
+                        'author_id' => 3,
                         'name' => 'Clara',
                         'replies' => null,
                         'threads' => null,
                     ],
                 ],
                 2 => [
-                    'reply_id' => '3',
-                    'thread_id' => '1',
-                    'author_id' => '4',
+                    'reply_id' => 3,
+                    'thread_id' => 1,
+                    'author_id' => 4,
                     'body' => 'Reply 3 on thread 1',
                     'author' => [
-                        'author_id' => '4',
+                        'author_id' => 4,
                         'name' => 'Donna',
                         'replies' => null,
                         'threads' => null,
                     ],
                 ],
                 3 => [
-                    'reply_id' => '4',
-                    'thread_id' => '1',
-                    'author_id' => '5',
+                    'reply_id' => 4,
+                    'thread_id' => 1,
+                    'author_id' => 5,
                     'body' => 'Reply 4 on thread 1',
                     'author' => [
-                        'author_id' => '5',
+                        'author_id' => 5,
                         'name' => 'Edna',
                         'replies' => null,
                         'threads' => null,
                     ],
                 ],
                 4 => [
-                    'reply_id' => '5',
-                    'thread_id' => '1',
-                    'author_id' => '6',
+                    'reply_id' => 5,
+                    'thread_id' => 1,
+                    'author_id' => 6,
                     'body' => 'Reply 5 on thread 1',
                     'author' => [
-                        'author_id' => '6',
+                        'author_id' => 6,
                         'name' => 'Fiona',
                         'replies' => null,
                         'threads' => null,
@@ -629,42 +628,42 @@ ORDER BY
             ],
             'taggings' => [
                 0 => [
-                    'tagging_id' => '1',
-                    'thread_id' => '1',
-                    'tag_id' => '1',
+                    'tagging_id' => 1,
+                    'thread_id' => 1,
+                    'tag_id' => 1,
                     'thread' => null,
                     'tag' => null,
                 ],
                 1 => [
-                    'tagging_id' => '2',
-                    'thread_id' => '1',
-                    'tag_id' => '2',
+                    'tagging_id' => 2,
+                    'thread_id' => 1,
+                    'tag_id' => 2,
                     'thread' => null,
                     'tag' => null,
                 ],
                 2 => [
-                    'tagging_id' => '3',
-                    'thread_id' => '1',
-                    'tag_id' => '3',
+                    'tagging_id' => 3,
+                    'thread_id' => 1,
+                    'tag_id' => 3,
                     'thread' => null,
                     'tag' => null,
                 ],
             ],
             'tags' => [
                 0 => [
-                    'tag_id' => '1',
+                    'tag_id' => 1,
                     'name' => 'foo',
                     'taggings' => null,
                     'threads' => null,
                 ],
                 1 => [
-                    'tag_id' => '2',
+                    'tag_id' => 2,
                     'name' => 'bar',
                     'taggings' => null,
                     'threads' => null,
                 ],
                 2 => [
-                    'tag_id' => '3',
+                    'tag_id' => 3,
                     'name' => 'baz',
                     'taggings' => null,
                     'threads' => null,
@@ -672,79 +671,79 @@ ORDER BY
             ],
         ],
         1 => [
-            'thread_id' => '2',
-            'author_id' => '2',
+            'thread_id' => 2,
+            'author_id' => 2,
             'subject' => 'Thread subject 2',
             'body' => 'Thread body 2',
             'author' => [
-                'author_id' => '2',
+                'author_id' => 2,
                 'name' => 'Betty',
                 'replies' => null,
                 'threads' => null,
             ],
             'summary' => [
-                'summary_id' => '2',
-                'thread_id' => '2',
-                'reply_count' => '5',
-                'view_count' => '0',
+                'summary_id' => 2,
+                'thread_id' => 2,
+                'reply_count' => 5,
+                'view_count' => 0,
                 'thread' => null,
             ],
             'replies' => [
                 0 => [
-                    'reply_id' => '6',
-                    'thread_id' => '2',
-                    'author_id' => '3',
+                    'reply_id' => 6,
+                    'thread_id' => 2,
+                    'author_id' => 3,
                     'body' => 'Reply 1 on thread 2',
                     'author' => [
-                        'author_id' => '3',
+                        'author_id' => 3,
                         'name' => 'Clara',
                         'replies' => null,
                         'threads' => null,
                     ],
                 ],
                 1 => [
-                    'reply_id' => '7',
-                    'thread_id' => '2',
-                    'author_id' => '4',
+                    'reply_id' => 7,
+                    'thread_id' => 2,
+                    'author_id' => 4,
                     'body' => 'Reply 2 on thread 2',
                     'author' => [
-                        'author_id' => '4',
+                        'author_id' => 4,
                         'name' => 'Donna',
                         'replies' => null,
                         'threads' => null,
                     ],
                 ],
                 2 => [
-                    'reply_id' => '8',
-                    'thread_id' => '2',
-                    'author_id' => '5',
+                    'reply_id' => 8,
+                    'thread_id' => 2,
+                    'author_id' => 5,
                     'body' => 'Reply 3 on thread 2',
                     'author' => [
-                        'author_id' => '5',
+                        'author_id' => 5,
                         'name' => 'Edna',
                         'replies' => null,
                         'threads' => null,
                     ],
                 ],
                 3 => [
-                    'reply_id' => '9',
-                    'thread_id' => '2',
-                    'author_id' => '6',
+                    'reply_id' => 9,
+                    'thread_id' => 2,
+                    'author_id' => 6,
                     'body' => 'Reply 4 on thread 2',
                     'author' => [
-                        'author_id' => '6',
+                        'author_id' => 6,
                         'name' => 'Fiona',
                         'replies' => null,
                         'threads' => null,
                     ],
                 ],
                 4 => [
-                    'reply_id' => '10',
-                    'thread_id' => '2',
-                    'author_id' => '7',
+                    'reply_id' => 10,
+                    'thread_id' => 2,
+                    'author_id' => 7,
                     'body' => 'Reply 5 on thread 2',
                     'author' => [
-                        'author_id' => '7',
+                        'author_id' => 7,
                         'name' => 'Gina',
                         'replies' => null,
                         'threads' => null,
@@ -753,42 +752,42 @@ ORDER BY
             ],
             'taggings' => [
                 0 => [
-                    'tagging_id' => '4',
-                    'thread_id' => '2',
-                    'tag_id' => '2',
+                    'tagging_id' => 4,
+                    'thread_id' => 2,
+                    'tag_id' => 2,
                     'thread' => null,
                     'tag' => null,
                 ],
                 1 => [
-                    'tagging_id' => '5',
-                    'thread_id' => '2',
-                    'tag_id' => '3',
+                    'tagging_id' => 5,
+                    'thread_id' => 2,
+                    'tag_id' => 3,
                     'thread' => null,
                     'tag' => null,
                 ],
                 2 => [
-                    'tagging_id' => '6',
-                    'thread_id' => '2',
-                    'tag_id' => '4',
+                    'tagging_id' => 6,
+                    'thread_id' => 2,
+                    'tag_id' => 4,
                     'thread' => null,
                     'tag' => null,
                 ],
             ],
             'tags' => [
                 0 => [
-                    'tag_id' => '2',
+                    'tag_id' => 2,
                     'name' => 'bar',
                     'taggings' => null,
                     'threads' => null,
                 ],
                 1 => [
-                    'tag_id' => '3',
+                    'tag_id' => 3,
                     'name' => 'baz',
                     'taggings' => null,
                     'threads' => null,
                 ],
                 2 => [
-                    'tag_id' => '4',
+                    'tag_id' => 4,
                     'name' => 'dib',
                     'taggings' => null,
                     'threads' => null,
@@ -796,79 +795,79 @@ ORDER BY
             ],
         ],
         2 => [
-            'thread_id' => '3',
-            'author_id' => '3',
+            'thread_id' => 3,
+            'author_id' => 3,
             'subject' => 'Thread subject 3',
             'body' => 'Thread body 3',
             'author' => [
-                'author_id' => '3',
+                'author_id' => 3,
                 'name' => 'Clara',
                 'replies' => null,
                 'threads' => null,
             ],
             'summary' => [
-                'summary_id' => '3',
-                'thread_id' => '3',
-                'reply_count' => '5',
-                'view_count' => '0',
+                'summary_id' => 3,
+                'thread_id' => 3,
+                'reply_count' => 5,
+                'view_count' => 0,
                 'thread' => null,
             ],
             'replies' => [
                 0 => [
-                    'reply_id' => '11',
-                    'thread_id' => '3',
-                    'author_id' => '4',
+                    'reply_id' => 11,
+                    'thread_id' => 3,
+                    'author_id' => 4,
                     'body' => 'Reply 1 on thread 3',
                     'author' => [
-                        'author_id' => '4',
+                        'author_id' => 4,
                         'name' => 'Donna',
                         'replies' => null,
                         'threads' => null,
                     ],
                 ],
                 1 => [
-                    'reply_id' => '12',
-                    'thread_id' => '3',
-                    'author_id' => '5',
+                    'reply_id' => 12,
+                    'thread_id' => 3,
+                    'author_id' => 5,
                     'body' => 'Reply 2 on thread 3',
                     'author' => [
-                        'author_id' => '5',
+                        'author_id' => 5,
                         'name' => 'Edna',
                         'replies' => null,
                         'threads' => null,
                     ],
                 ],
                 2 => [
-                    'reply_id' => '13',
-                    'thread_id' => '3',
-                    'author_id' => '6',
+                    'reply_id' => 13,
+                    'thread_id' => 3,
+                    'author_id' => 6,
                     'body' => 'Reply 3 on thread 3',
                     'author' => [
-                        'author_id' => '6',
+                        'author_id' => 6,
                         'name' => 'Fiona',
                         'replies' => null,
                         'threads' => null,
                     ],
                 ],
                 3 => [
-                    'reply_id' => '14',
-                    'thread_id' => '3',
-                    'author_id' => '7',
+                    'reply_id' => 14,
+                    'thread_id' => 3,
+                    'author_id' => 7,
                     'body' => 'Reply 4 on thread 3',
                     'author' => [
-                        'author_id' => '7',
+                        'author_id' => 7,
                         'name' => 'Gina',
                         'replies' => null,
                         'threads' => null,
                     ],
                 ],
                 4 => [
-                    'reply_id' => '15',
-                    'thread_id' => '3',
-                    'author_id' => '8',
+                    'reply_id' => 15,
+                    'thread_id' => 3,
+                    'author_id' => 8,
                     'body' => 'Reply 5 on thread 3',
                     'author' => [
-                        'author_id' => '8',
+                        'author_id' => 8,
                         'name' => 'Hanna',
                         'replies' => null,
                         'threads' => null,

--- a/tests/DataSource/Author/AuthorTable.php
+++ b/tests/DataSource/Author/AuthorTable.php
@@ -39,6 +39,7 @@ class AuthorTable extends AbstractTable
             'author_id' => (object) [
                 'name' => 'author_id',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,
@@ -49,6 +50,7 @@ class AuthorTable extends AbstractTable
             'name' => (object) [
                 'name' => 'name',
                 'type' => 'varchar',
+                'mapTo' => 'string',
                 'size' => 10,
                 'scale' => null,
                 'notnull' => true,

--- a/tests/DataSource/Course/CourseTable.php
+++ b/tests/DataSource/Course/CourseTable.php
@@ -40,6 +40,7 @@ class CourseTable extends AbstractTable
             'course_subject' => (object) [
                 'name' => 'course_subject',
                 'type' => 'char',
+                'mapTo' => 'string',
                 'size' => 4,
                 'scale' => null,
                 'notnull' => false,
@@ -50,6 +51,7 @@ class CourseTable extends AbstractTable
             'course_number' => (object) [
                 'name' => 'course_number',
                 'type' => 'int',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,
@@ -60,6 +62,7 @@ class CourseTable extends AbstractTable
             'title' => (object) [
                 'name' => 'title',
                 'type' => 'varchar',
+                'mapTo' => 'string',
                 'size' => 20,
                 'scale' => null,
                 'notnull' => false,

--- a/tests/DataSource/Degree/DegreeTable.php
+++ b/tests/DataSource/Degree/DegreeTable.php
@@ -40,6 +40,7 @@ class DegreeTable extends AbstractTable
             'degree_type' => (object) [
                 'name' => 'degree_type',
                 'type' => 'char',
+                'mapTo' => 'string',
                 'size' => 2,
                 'scale' => null,
                 'notnull' => false,
@@ -50,6 +51,7 @@ class DegreeTable extends AbstractTable
             'degree_subject' => (object) [
                 'name' => 'degree_subject',
                 'type' => 'char',
+                'mapTo' => 'string',
                 'size' => 4,
                 'scale' => null,
                 'notnull' => false,
@@ -60,6 +62,7 @@ class DegreeTable extends AbstractTable
             'title' => (object) [
                 'name' => 'title',
                 'type' => 'varchar',
+                'mapTo' => 'string',
                 'size' => 50,
                 'scale' => null,
                 'notnull' => false,

--- a/tests/DataSource/Employee/EmployeeTable.php
+++ b/tests/DataSource/Employee/EmployeeTable.php
@@ -41,6 +41,7 @@ class EmployeeTable extends AbstractTable
             'id' => (object) [
                 'name' => 'id',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,
@@ -51,6 +52,7 @@ class EmployeeTable extends AbstractTable
             'name' => (object) [
                 'name' => 'name',
                 'type' => 'varchar',
+                'mapTo' => 'string',
                 'size' => 10,
                 'scale' => null,
                 'notnull' => true,
@@ -61,6 +63,7 @@ class EmployeeTable extends AbstractTable
             'building' => (object) [
                 'name' => 'building',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,
@@ -71,6 +74,7 @@ class EmployeeTable extends AbstractTable
             'floor' => (object) [
                 'name' => 'floor',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,

--- a/tests/DataSource/Enrollment/EnrollmentTable.php
+++ b/tests/DataSource/Enrollment/EnrollmentTable.php
@@ -43,6 +43,7 @@ class EnrollmentTable extends AbstractTable
             'student_fn' => (object) [
                 'name' => 'student_fn',
                 'type' => 'varchar',
+                'mapTo' => 'string',
                 'size' => 10,
                 'scale' => null,
                 'notnull' => false,
@@ -53,6 +54,7 @@ class EnrollmentTable extends AbstractTable
             'student_ln' => (object) [
                 'name' => 'student_ln',
                 'type' => 'varchar',
+                'mapTo' => 'string',
                 'size' => 10,
                 'scale' => null,
                 'notnull' => false,
@@ -63,6 +65,7 @@ class EnrollmentTable extends AbstractTable
             'course_subject' => (object) [
                 'name' => 'course_subject',
                 'type' => 'char',
+                'mapTo' => 'string',
                 'size' => 4,
                 'scale' => null,
                 'notnull' => false,
@@ -73,6 +76,7 @@ class EnrollmentTable extends AbstractTable
             'course_number' => (object) [
                 'name' => 'course_number',
                 'type' => 'int',
+                'mapTo' => 'int',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,
@@ -83,6 +87,7 @@ class EnrollmentTable extends AbstractTable
             'grade' => (object) [
                 'name' => 'grade',
                 'type' => 'int',
+                'mapTo' => 'int',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,
@@ -93,6 +98,7 @@ class EnrollmentTable extends AbstractTable
             'points' => (object) [
                 'name' => 'points',
                 'type' => 'int',
+                'mapTo' => 'int',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,

--- a/tests/DataSource/Gpa/GpaTable.php
+++ b/tests/DataSource/Gpa/GpaTable.php
@@ -40,6 +40,7 @@ class GpaTable extends AbstractTable
             'student_fn' => (object) [
                 'name' => 'student_fn',
                 'type' => 'varchar',
+                'mapTo' => 'string',
                 'size' => 10,
                 'scale' => null,
                 'notnull' => false,
@@ -50,6 +51,7 @@ class GpaTable extends AbstractTable
             'student_ln' => (object) [
                 'name' => 'student_ln',
                 'type' => 'varchar',
+                'mapTo' => 'string',
                 'size' => 10,
                 'scale' => null,
                 'notnull' => false,
@@ -60,6 +62,7 @@ class GpaTable extends AbstractTable
             'gpa' => (object) [
                 'name' => 'gpa',
                 'type' => 'decimal',
+                'mapTo' => 'float',
                 'size' => 4,
                 'scale' => 3,
                 'notnull' => false,

--- a/tests/DataSource/Reply/ReplyTable.php
+++ b/tests/DataSource/Reply/ReplyTable.php
@@ -41,6 +41,7 @@ class ReplyTable extends AbstractTable
             'reply_id' => (object) [
                 'name' => 'reply_id',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,
@@ -51,6 +52,7 @@ class ReplyTable extends AbstractTable
             'thread_id' => (object) [
                 'name' => 'thread_id',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => true,
@@ -61,6 +63,7 @@ class ReplyTable extends AbstractTable
             'author_id' => (object) [
                 'name' => 'author_id',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => true,
@@ -71,6 +74,7 @@ class ReplyTable extends AbstractTable
             'body' => (object) [
                 'name' => 'body',
                 'type' => 'text',
+                'mapTo' => 'string',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,

--- a/tests/DataSource/Student/StudentTable.php
+++ b/tests/DataSource/Student/StudentTable.php
@@ -41,6 +41,7 @@ class StudentTable extends AbstractTable
             'student_fn' => (object) [
                 'name' => 'student_fn',
                 'type' => 'varchar',
+                'mapTo' => 'string',
                 'size' => 10,
                 'scale' => null,
                 'notnull' => false,
@@ -51,6 +52,7 @@ class StudentTable extends AbstractTable
             'student_ln' => (object) [
                 'name' => 'student_ln',
                 'type' => 'varchar',
+                'mapTo' => 'string',
                 'size' => 10,
                 'scale' => null,
                 'notnull' => false,
@@ -61,6 +63,7 @@ class StudentTable extends AbstractTable
             'degree_type' => (object) [
                 'name' => 'degree_type',
                 'type' => 'char',
+                'mapTo' => 'string',
                 'size' => 2,
                 'scale' => null,
                 'notnull' => false,
@@ -71,6 +74,7 @@ class StudentTable extends AbstractTable
             'degree_subject' => (object) [
                 'name' => 'degree_subject',
                 'type' => 'char',
+                'mapTo' => 'string',
                 'size' => 4,
                 'scale' => null,
                 'notnull' => false,

--- a/tests/DataSource/Summary/SummaryTable.php
+++ b/tests/DataSource/Summary/SummaryTable.php
@@ -41,6 +41,7 @@ class SummaryTable extends AbstractTable
             'summary_id' => (object) [
                 'name' => 'summary_id',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,
@@ -51,6 +52,7 @@ class SummaryTable extends AbstractTable
             'thread_id' => (object) [
                 'name' => 'thread_id',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => true,
@@ -61,6 +63,7 @@ class SummaryTable extends AbstractTable
             'reply_count' => (object) [
                 'name' => 'reply_count',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => true,
@@ -71,6 +74,7 @@ class SummaryTable extends AbstractTable
             'view_count' => (object) [
                 'name' => 'view_count',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => true,

--- a/tests/DataSource/Tag/TagTable.php
+++ b/tests/DataSource/Tag/TagTable.php
@@ -39,6 +39,7 @@ class TagTable extends AbstractTable
             'tag_id' => (object) [
                 'name' => 'tag_id',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,
@@ -49,6 +50,7 @@ class TagTable extends AbstractTable
             'name' => (object) [
                 'name' => 'name',
                 'type' => 'varchar',
+                'mapTo' => 'string',
                 'size' => 10,
                 'scale' => null,
                 'notnull' => true,

--- a/tests/DataSource/Tagging/TaggingTable.php
+++ b/tests/DataSource/Tagging/TaggingTable.php
@@ -40,6 +40,7 @@ class TaggingTable extends AbstractTable
             'tagging_id' => (object) [
                 'name' => 'tagging_id',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,
@@ -50,6 +51,7 @@ class TaggingTable extends AbstractTable
             'thread_id' => (object) [
                 'name' => 'thread_id',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => true,
@@ -60,6 +62,7 @@ class TaggingTable extends AbstractTable
             'tag_id' => (object) [
                 'name' => 'tag_id',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => true,

--- a/tests/DataSource/Thread/ThreadTable.php
+++ b/tests/DataSource/Thread/ThreadTable.php
@@ -41,6 +41,7 @@ class ThreadTable extends AbstractTable
             'thread_id' => (object) [
                 'name' => 'thread_id',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => false,
@@ -51,6 +52,7 @@ class ThreadTable extends AbstractTable
             'author_id' => (object) [
                 'name' => 'author_id',
                 'type' => 'integer',
+                'mapTo' => 'integer',
                 'size' => null,
                 'scale' => null,
                 'notnull' => true,
@@ -61,6 +63,7 @@ class ThreadTable extends AbstractTable
             'subject' => (object) [
                 'name' => 'subject',
                 'type' => 'varchar',
+                'mapTo' => 'string',
                 'size' => 255,
                 'scale' => null,
                 'notnull' => true,
@@ -71,6 +74,7 @@ class ThreadTable extends AbstractTable
             'body' => (object) [
                 'name' => 'body',
                 'type' => 'text',
+                'mapTo' => 'string',
                 'size' => null,
                 'scale' => null,
                 'notnull' => true,

--- a/tests/Mapper/MapperCompositeTest.php
+++ b/tests/Mapper/MapperCompositeTest.php
@@ -1,12 +1,13 @@
 <?php
+
 namespace Atlas\Orm\Mapper;
 
 use Atlas\Orm\DataSource\Course\CourseMapper;
 use Atlas\Orm\DataSource\Course\CourseTable;
 use Atlas\Orm\Relationship\Relationships;
 use Atlas\Orm\SqliteFixture;
-use Atlas\Orm\Table\TableEvents;
 use Atlas\Orm\Table\IdentityMap;
+use Atlas\Orm\Table\TableEvents;
 use Aura\Sql\ConnectionLocator;
 use Aura\Sql\ExtendedPdo;
 use Aura\SqlQuery\QueryFactory;
@@ -46,14 +47,14 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
     {
         $expect = [
             'course_subject' => 'MATH',
-            'course_number' => '100',
+            'course_number' => 100,
             'title' => 'Algebra',
         ];
 
         // fetch success
         $record1 = $this->mapper->fetchRecord([
             'course_subject' => 'MATH',
-            'course_number' => '100',
+            'course_number' => 100,
         ]);
         $this->assertInstanceOf(Record::CLASS, $record1);
         $row1 = $record1->getRow();
@@ -62,7 +63,7 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
         // fetch again
         $record2 = $this->mapper->fetchRecord([
             'course_subject' => 'MATH',
-            'course_number' => '100',
+            'course_number' => 100,
         ]);
         $this->assertInstanceOf(Record::CLASS, $record2);
         $this->assertNotSame($record1, $record2);
@@ -72,7 +73,7 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
         // fetch failure
         $actual = $this->mapper->fetchRecord([
             'course_subject' => 'NONE',
-            'course_number' => '999',
+            'course_number' => 999,
         ]);
         $this->assertFalse($actual);
     }
@@ -81,7 +82,7 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
     {
         $expect = [
             'course_subject' => 'MATH',
-            'course_number' => '100',
+            'course_number' => 100,
             'title' => 'Algebra',
         ];
 
@@ -107,14 +108,14 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
     {
         $expect = [
             'course_subject' => 'MATH',
-            'course_number' => '100',
+            'course_number' => 100,
             'title' => 'Algebra',
         ];
 
         // fetch success
         $select = $this->mapper->select([
             'course_subject' => 'MATH',
-            'course_number' => '100',
+            'course_number' => 100,
         ]);
         $record1 = $select->fetchRecord();
         $this->assertInstanceOf(Record::CLASS, $record1);
@@ -131,7 +132,7 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
         // fetch failure
         $select = $this->mapper->select([
             'course_subject' => 'NONE',
-            'course_number' => '999',
+            'course_number' => 999,
         ]);
         $actual = $select->fetchRecord();
         $this->assertFalse($actual);
@@ -140,15 +141,15 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
     public function testFetchRecordSet()
     {
         $expect = [
-            ['course_subject' => 'ENGL', 'course_number' => '100', 'title' => 'Composition'],
-            ['course_subject' => 'HIST', 'course_number' => '200', 'title' => 'US History'],
-            ['course_subject' => 'MATH', 'course_number' => '300', 'title' => 'Calculus'],
+            ['course_subject' => 'ENGL', 'course_number' => 100, 'title' => 'Composition'],
+            ['course_subject' => 'HIST', 'course_number' => 200, 'title' => 'US History'],
+            ['course_subject' => 'MATH', 'course_number' => 300, 'title' => 'Calculus'],
         ];
 
         $actual = $this->mapper->fetchRecordSet([
-            ['course_subject' => 'ENGL', 'course_number' => '100'],
-            ['course_subject' => 'HIST', 'course_number' => '200'],
-            ['course_subject' => 'MATH', 'course_number' => '300'],
+            ['course_subject' => 'ENGL', 'course_number' => 100],
+            ['course_subject' => 'HIST', 'course_number' => 200],
+            ['course_subject' => 'MATH', 'course_number' => 300],
         ]);
         $this->assertInstanceOf(RecordSet::CLASS, $actual);
         $this->assertCount(3, $actual);
@@ -160,9 +161,9 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect[2], $actual[2]->getRow()->getArrayCopy());
 
         $again = $this->mapper->fetchRecordSet([
-            ['course_subject' => 'ENGL', 'course_number' => '100'],
-            ['course_subject' => 'HIST', 'course_number' => '200'],
-            ['course_subject' => 'MATH', 'course_number' => '300'],
+            ['course_subject' => 'ENGL', 'course_number' => 100],
+            ['course_subject' => 'HIST', 'course_number' => 200],
+            ['course_subject' => 'MATH', 'course_number' => 300],
         ]);
         $this->assertInstanceOf(RecordSet::CLASS, $again);
         $this->assertCount(3, $again);
@@ -174,9 +175,9 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($actual[2]->getRow(), $again[2]->getRow());
 
         $actual = $this->mapper->fetchRecordSet([
-            ['course_subject' => 'ENGL', 'course_number' => '999'],
-            ['course_subject' => 'HIST', 'course_number' => '999'],
-            ['course_subject' => 'MATH', 'course_number' => '999'],
+            ['course_subject' => 'ENGL', 'course_number' => 999],
+            ['course_subject' => 'HIST', 'course_number' => 999],
+            ['course_subject' => 'MATH', 'course_number' => 999],
         ]);
         $this->assertSame([], $actual);
     }
@@ -184,10 +185,10 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
     public function testFetchRecordSetBy()
     {
         $expect = [
-            ['course_subject' => 'HIST', 'course_number' => '100', 'title' => 'World History'],
-            ['course_subject' => 'HIST', 'course_number' => '200', 'title' => 'US History'],
-            ['course_subject' => 'HIST', 'course_number' => '300', 'title' => 'Victorian History'],
-            ['course_subject' => 'HIST', 'course_number' => '400', 'title' => 'Recent History'],
+            ['course_subject' => 'HIST', 'course_number' => 100, 'title' => 'World History'],
+            ['course_subject' => 'HIST', 'course_number' => 200, 'title' => 'US History'],
+            ['course_subject' => 'HIST', 'course_number' => 300, 'title' => 'Victorian History'],
+            ['course_subject' => 'HIST', 'course_number' => 400, 'title' => 'Recent History'],
         ];
 
         $actual = $this->mapper->fetchRecordSetBy(['course_subject' => 'HIST']);
@@ -220,10 +221,10 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
     public function testSelectFetchRecordSet()
     {
         $expect = [
-            ['course_subject' => 'HIST', 'course_number' => '100', 'title' => 'World History'],
-            ['course_subject' => 'HIST', 'course_number' => '200', 'title' => 'US History'],
-            ['course_subject' => 'HIST', 'course_number' => '300', 'title' => 'Victorian History'],
-            ['course_subject' => 'HIST', 'course_number' => '400', 'title' => 'Recent History'],
+            ['course_subject' => 'HIST', 'course_number' => 100, 'title' => 'World History'],
+            ['course_subject' => 'HIST', 'course_number' => 200, 'title' => 'US History'],
+            ['course_subject' => 'HIST', 'course_number' => 300, 'title' => 'Victorian History'],
+            ['course_subject' => 'HIST', 'course_number' => 400, 'title' => 'Recent History'],
         ];
 
         $select = $this->mapper->select(['course_subject' => 'HIST']);
@@ -257,7 +258,7 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
     {
         $record = $this->mapper->newRecord([
             'course_subject' => 'PHIL',
-            'course_number' => '100',
+            'course_number' => 100,
             'title' => 'Greek Philosophy',
         ]);
 
@@ -268,7 +269,7 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
         // did it save in the identity map?
         $again = $this->mapper->fetchRecord([
             'course_subject' => 'PHIL',
-            'course_number' => '100',
+            'course_number' => 100,
         ]);
         $this->assertSame($record->getRow(), $again->getRow());
 
@@ -297,7 +298,7 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
         // fetch a record, then modify and update it
         $record = $this->mapper->fetchRecordBy([
             'course_subject' => 'MATH',
-            'course_number' => '100',
+            'course_number' => 100,
         ]);
         $record->title = 'Algebra I';
 
@@ -308,7 +309,7 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
         // is it still in the identity map?
         $again = $this->mapper->fetchRecordBy([
             'course_subject' => 'MATH',
-            'course_number' => '100',
+            'course_number' => 100,
         ]);
         $this->assertSame($record->getRow(), $again->getRow());
 
@@ -317,7 +318,9 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
         $actual = $this->mapper->getReadConnection()->fetchOne(
             "SELECT * FROM courses WHERE course_subject = 'MATH' AND course_number = '100'"
         );
-        $this->assertSame($expect, $actual);
+
+        // Will assert equals but not same because the 'course_number' has been casted in integer
+        $this->assertEquals($expect, $actual);
 
         // try to update again, should be a no-op because there are no changes
         $this->assertFalse($this->mapper->update($record));
@@ -328,14 +331,14 @@ class MapperCompositeTest extends \PHPUnit_Framework_TestCase
         // fetch a record, then delete it
         $record = $this->mapper->fetchRecordBy([
             'course_subject' => 'MATH',
-            'course_number' => '100',
+            'course_number' => 100,
         ]);
         $this->mapper->delete($record);
 
         // did it delete?
         $actual = $this->mapper->fetchRecordBy([
             'course_subject' => 'MATH',
-            'course_number' => '100',
+            'course_number' => 100,
         ]);
         $this->assertFalse($actual);
 

--- a/tests/Mapper/MapperTest.php
+++ b/tests/Mapper/MapperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Atlas\Orm\Mapper;
 
 use Atlas\Orm\Assertions;
@@ -51,10 +52,10 @@ class MapperTest extends \PHPUnit_Framework_TestCase
     public function testFetchRecord()
     {
         $expect = [
-            'id' => '1',
+            'id' => 1,
             'name' => 'Anna',
-            'building' => '1',
-            'floor' => '1',
+            'building' => 1,
+            'floor' => 1,
         ];
 
         // fetch success
@@ -78,10 +79,10 @@ class MapperTest extends \PHPUnit_Framework_TestCase
     public function testFetchRecordBy()
     {
         $expect = [
-            'id' => '1',
+            'id' => 1,
             'name' => 'Anna',
-            'building' => '1',
-            'floor' => '1',
+            'building' => 1,
+            'floor' => 1,
         ];
 
         // fetch success
@@ -105,10 +106,10 @@ class MapperTest extends \PHPUnit_Framework_TestCase
     public function testSelectFetchRecord()
     {
         $expect = [
-            'id' => '1',
+            'id' => 1,
             'name' => 'Anna',
-            'building' => '1',
-            'floor' => '1',
+            'building' => 1,
+            'floor' => 1,
         ];
 
         // fetch success
@@ -135,22 +136,22 @@ class MapperTest extends \PHPUnit_Framework_TestCase
     {
         $expect = [
             [
-                'id' => '1',
+                'id' => 1,
                 'name' => 'Anna',
-                'building' => '1',
-                'floor' => '1',
+                'building' => 1,
+                'floor' => 1,
             ],
             [
-                'id' => '2',
+                'id' => 2,
                 'name' => 'Betty',
-                'building' => '1',
-                'floor' => '2',
+                'building' => 1,
+                'floor' => 2,
             ],
             [
-                'id' => '3',
+                'id' => 3,
                 'name' => 'Clara',
-                'building' => '1',
-                'floor' => '3',
+                'building' => 1,
+                'floor' => 3,
             ],
         ];
 
@@ -182,22 +183,22 @@ class MapperTest extends \PHPUnit_Framework_TestCase
     {
         $expect = [
             [
-                'id' => '1',
+                'id' => 1,
                 'name' => 'Anna',
-                'building' => '1',
-                'floor' => '1',
+                'building' => 1,
+                'floor' => 1,
             ],
             [
-                'id' => '2',
+                'id' => 2,
                 'name' => 'Betty',
-                'building' => '1',
-                'floor' => '2',
+                'building' => 1,
+                'floor' => 2,
             ],
             [
-                'id' => '3',
+                'id' => 3,
                 'name' => 'Clara',
-                'building' => '1',
-                'floor' => '3',
+                'building' => 1,
+                'floor' => 3,
             ],
         ];
 
@@ -229,22 +230,22 @@ class MapperTest extends \PHPUnit_Framework_TestCase
     {
         $expect = [
             [
-                'id' => '1',
+                'id' => 1,
                 'name' => 'Anna',
-                'building' => '1',
-                'floor' => '1',
+                'building' => 1,
+                'floor' => 1,
             ],
             [
-                'id' => '2',
+                'id' => 2,
                 'name' => 'Betty',
-                'building' => '1',
-                'floor' => '2',
+                'building' => 1,
+                'floor' => 2,
             ],
             [
-                'id' => '3',
+                'id' => 3,
                 'name' => 'Clara',
-                'building' => '1',
-                'floor' => '3',
+                'building' => 1,
+                'floor' => 3,
             ],
         ];
 
@@ -261,7 +262,7 @@ class MapperTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($actual[1]->getRow(), $again[1]->getRow());
         $this->assertSame($actual[2]->getRow(), $again[2]->getRow());
 
-        $select = $this->mapper->select(['id' => [997,998,999]]);
+        $select = $this->mapper->select(['id' => [997, 998, 999]]);
         $actual = $select->fetchRecordSet();
         $this->assertSame([], $actual);
     }
@@ -326,7 +327,8 @@ class MapperTest extends \PHPUnit_Framework_TestCase
         $actual = $this->mapper->getReadConnection()->fetchOne(
             "SELECT * FROM employee WHERE name = 'Annabelle'"
         );
-        $this->assertSame($expect, $actual);
+        // Will assert equals but not same because the 'id, building, floor' have been casted in integer
+        $this->assertEquals($expect, $actual);
 
         // try to update again, should be a no-op because there are no changes
         $this->assertFalse($this->mapper->update($record));


### PR DESCRIPTION
Specifying a 'mapTo' key in an entry of the array returned by getCols method in TableInterface, the value will be casted using the settype php function.

This is incredibly useful when using type hinting in an entity (an example [here](https://github.com/atlasphp/Atlas.Orm/blob/1.x/docs/domain.md#map-from-persistence-to-domain))

[Example here](https://github.com/atlasphp/Atlas.Orm/commit/c5cab6fa7a7ac2156b20428b976444dcfbbabb0e#diff-f7c15242b8576acfcc84013adabba16a) from EmployeeTable.php in tests