### PR TITLE
Add support for refreshing a single record in a table's IdentityMap

### DIFF
--- a/src/Table/AbstractTable.php
+++ b/src/Table/AbstractTable.php
@@ -185,6 +185,26 @@ abstract class AbstractTable implements TableInterface
 
     /**
      *
+     * Refetches a row, and updates it in the identity map.
+     *
+     * Note: This will revert any unpersisted changes to the row instance.
+     *
+     * @param RowInterface $row The row to refetch
+     *
+     */
+    public function refreshRow(RowInterface $row): void
+    {
+        $select = $this->select()->cols($this->getColNames());
+        foreach ($this->getPrimaryKey() as $primaryCol) {
+            $select->where("{$primaryCol} = ?", $row->$primaryCol);
+        }
+        $cols = $select->fetchOne();
+        $row->set($cols);
+        $this->identityMap->resetInitial($row);
+    }
+
+    /**
+     *
      * Fetches an array of Row objects based on primary-key values, from the
      * identity map as available, and from the database when not.
      *

--- a/src/Table/IdentityMap.php
+++ b/src/Table/IdentityMap.php
@@ -121,6 +121,18 @@ class IdentityMap
 
     /**
      *
+     * Returns a list of mapped rows.
+     *
+     * @return array The mapped Rows.
+     *
+     */
+    public function getAll() : array
+    {
+        return array_vals($this->serialToRow);
+    }
+
+    /**
+     *
      * This is a ghetto hack to serialize a composite primary key to a string,
      * so it can be used for array key lookups. It works just as well for
      * single-value keys as well.

--- a/tests/Table/TableTest.php
+++ b/tests/Table/TableTest.php
@@ -68,7 +68,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $this->table->updateRow($row);
     }
 
-    public function testRefreshRow()
+    public function testReloadRow()
     {
         $row = $this->table->newRow([
             'name' => 'Foobar',
@@ -78,8 +78,8 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $this->table->insertRow($row);
         $row->name = 'Bazbing';
         $this->identityMap->resetInitial($row);
-        $this->table->refreshRow($row);
-        
+        $this->table->reloadRow($row);
+
         $this->assertSame('Foobar', $row->name);
         $this->assertEquals($this->identityMap->getInitial($row), $row->getArrayCopy());
     }

--- a/tests/Table/TableTest.php
+++ b/tests/Table/TableTest.php
@@ -36,7 +36,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($this->identityMap, $this->table->getIdentityMap());
     }
 
-    public function testTnsertUpdateDeleteRow()
+    public function testInsertUpdateDeleteRow()
     {
         $row = $this->table->newRow([
             'name' => 'Foobar',
@@ -66,5 +66,21 @@ class TableTest extends \PHPUnit\Framework\TestCase
             "Primary key value for 'id' changed from '1' to '2'"
         );
         $this->table->updateRow($row);
+    }
+
+    public function testRefreshRow()
+    {
+        $row = $this->table->newRow([
+            'name' => 'Foobar',
+            'building' => 99,
+            'floor' => 1
+        ]);
+        $this->table->insertRow($row);
+        $row->name = 'Bazbing';
+        $this->identityMap->resetInitial($row);
+        $this->table->refreshRow($row);
+        
+        $this->assertSame('Foobar', $row->name);
+        $this->assertEquals($this->identityMap->getInitial($row), $row->getArrayCopy());
     }
 }


### PR DESCRIPTION
Opening this up for discussion / inclusion.

Essentially the issue I'm seeing is that if something non Atlas changes a row in the db (separate process, or same process, but arbitrarily executed SQL), there appears to be no way to signal to Atlas to force a refetch of the affected rows. The next time you attempt to read the row, the stale version from the identity map will be returned.

Added a single method to the AbstractTable to allow for manually resetting the in memory row instance to the representation in the database.