### PR TITLE
Throw current exception instead of recreate them

### DIFF
--- a/src/Transaction/AutoTransact.php
+++ b/src/Transaction/AutoTransact.php
@@ -33,8 +33,7 @@ class AutoTransact extends Transaction
             $this->commit();
         } catch (Exception $e) {
             $this->rollBack();
-            $c = get_class($e);
-            throw new $c($e->getMessage(), $e->getCode(), $e);
+            throw $e;
         }
     }
 }

--- a/tests/Transaction/AutoTransactTest.php
+++ b/tests/Transaction/AutoTransactTest.php
@@ -27,9 +27,8 @@ class AutoTransactTest extends TransactionTest
             $employee->id = '999';
             $this->atlas->persist($employee);
         } catch (Exception $e) {
-            $previous = $e->getPrevious();
             $this->assertSame(
-                $previous->getMessage(),
+                $e->getMessage(),
                 "Primary key value for 'id' changed"
             );
         }


### PR DESCRIPTION
Hello,

In case of some exceptions, order of parameters is not the same as Exception.
```
Error: Wrong parameters for PDOException([string $message [, long $code [, Throwable $previous = NULL]]])
```

So throw the current exception instead of recreate them is preferable.

Ronan