### PR TITLE
In Row::isEquivalent(), compare bools as ints

### DIFF
--- a/src/Table/Row.php
+++ b/src/Table/Row.php
@@ -354,6 +354,9 @@ class Row implements RowInterface
      */
     protected function isEquivalent($old, $new) : bool
     {
+        $old = is_bool($old) ? (int) $old : $old;
+        $new = is_bool($new) ? (int) $new : $new;
+
         return (is_numeric($old) && is_numeric($new))
             ? $old == $new // numeric, compare loosely
             : $old === $new; // not numeric, compare strictly

--- a/tests/Table/RowTest.php
+++ b/tests/Table/RowTest.php
@@ -113,4 +113,32 @@ class RowTest extends \PHPUnit\Framework\TestCase
         $expect = '{"id":"1","foo":"bar"}';
         $this->assertSame($expect, $actual);
     }
+
+    public function testIsEquivalent_numericToBool()
+    {
+        $init = ['id' => '1', 'foo' => 1];
+        $row = new Row($init);
+
+        $row->foo = true;
+        $diff = $row->getArrayDiff($init);
+        $this->assertEmpty($diff);
+
+        $row->foo = false;
+        $diff = $row->getArrayDiff($init);
+        $this->assertSame(['foo' => false], $diff);
+    }
+
+    public function testIsEquivalent_boolToNumeric()
+    {
+        $init = ['id' => '1', 'foo' => true];
+        $row = new Row($init);
+
+        $row->foo = 1;
+        $diff = $row->getArrayDiff($init);
+        $this->assertEmpty($diff);
+
+        $row->foo = 0;
+        $diff = $row->getArrayDiff($init);
+        $this->assertSame(['foo' => 0], $diff);
+    }
 }


### PR DESCRIPTION
This should help reduce ""Expected 1 row affected, actual 0" errors when the Row array diff indicates a change from true to 1, or false to 0, and vice versa.